### PR TITLE
skipped authentication at van index

### DIFF
--- a/app/controllers/vans_controller.rb
+++ b/app/controllers/vans_controller.rb
@@ -1,5 +1,8 @@
 class VansController < ApplicationController
   before_action :set_van, only: [:show]
+
+  # Allow unsigned-in users to see index page.
+  skip_before_action :authenticate_user!, only: [:index]
   def index
     @vans = policy_scope(Van)
 


### PR DESCRIPTION
User can see also the van's index when not signed in. 